### PR TITLE
DK2-112 Best Matched Repository Box Shadow 

### DIFF
--- a/applications/dknet/frontend/src/theme/Theme.tsx
+++ b/applications/dknet/frontend/src/theme/Theme.tsx
@@ -20,7 +20,6 @@ const {
   warning50,
   warning300,
   dialogBoxShadow,
-  repoSuccessBoxshadow
 } = vars;
 
 const theme = createTheme({
@@ -170,7 +169,7 @@ const theme = createTheme({
           '&.successCard': {
             background: primary25,
             border:`1px solid ${primary200}`,
-            boxShadow: repoSuccessBoxshadow
+            boxShadow: dialogBoxShadow
           }
         }
       }

--- a/applications/dknet/frontend/src/theme/variables.js
+++ b/applications/dknet/frontend/src/theme/variables.js
@@ -37,5 +37,4 @@ export const vars = {
   cardBorderColor: '#83DCB2',
   cardBgColor: '#F8FDFA',
   cardChipBgColor: '#F2F4F7', 
-  repoSuccessBoxshadow: "0px 20px 24px -4px rgba(16, 24, 40, 0.08), 0px 8px 8px -4px rgba(16, 24, 40, 0.03)" 
 };


### PR DESCRIPTION
Issue #DK2-112
Problem: When you hover over a repository card it should be green with a shadow
Solution: Just box-shadow property to successCard class
![image](https://user-images.githubusercontent.com/67194168/234088210-a027261f-d6b5-4d58-917e-54236f19a8bb.png)
