### PR TITLE
DK2-113 Match the layout of the figma for the filters on the right hand side of the main page

### DIFF
--- a/applications/dknet/frontend/src/pages/HomePage.tsx
+++ b/applications/dknet/frontend/src/pages/HomePage.tsx
@@ -44,7 +44,7 @@ const HomePage = () => {
   }, [context])
 
   return (
-    <Container>
+    <Container disableGutters>
       <Grid container columnSpacing={4}>
         <Grid md={8} item>
           <Grid spacing={2}>

--- a/applications/dknet/frontend/src/theme/Theme.tsx
+++ b/applications/dknet/frontend/src/theme/Theme.tsx
@@ -150,16 +150,7 @@ const theme = createTheme({
       }
       `
     },
-    MuiContainer: {
-      styleOverrides:{
-        root: {
-          '&.MuiContainer-root': {
-            padding: 0
-          }
-        }
-      }
-    },
-
+    
     MuiCheckbox: {
       styleOverrides: {
         root: {


### PR DESCRIPTION
<img width="1080" alt="image" src="https://github.com/MetaCell/dknet/assets/67194168/ddd67721-4fee-44a1-b945-35901b2a7bf5">
Solution: 
I changed spacing between two components to be 32px to match the figma design, also it is because two components should have padding left and right to be 32px between them and main container, column spacing works for the repositories component, but I didn't add padding right to the filters component, because it makes it even smaller.
