### PR TITLE
DK2-115 Amend the checkbox multi-select to match the Figma design 

### DIFF
--- a/applications/dknet/frontend/src/components/Search.tsx
+++ b/applications/dknet/frontend/src/components/Search.tsx
@@ -34,16 +34,20 @@ const Search = () => {
       <CustomAutoComplete
         options={context.allFilters[0].options}
         onChangeFilterValue={(value) => onChangeFilterValue(value, context.allFilters[0])}
+        isOptionEqualToValue={(option, value) => option.code === value.code}
         defaultValue={context.filterValues[context.allFilters[0].code] || []}
         placeholder={context.allFilters[0].label}
+        noOptionsText={"No match"}
       />
 
       <Divider sx={{ height: 40, mr: 1, ml: 1 }} orientation="vertical" />
       <CustomAutoComplete
         options={context.allFilters[1].options}
         onChangeFilterValue={(value) => onChangeFilterValue(value, context.allFilters[1])}
+        isOptionEqualToValue={(option, value) => option.code === value.code}
         defaultValue={context.filterValues[context.allFilters[1].code] || []}
         placeholder={context.allFilters[1].label}
+        noOptionsText={"No match"}
       />
 
       <Divider sx={{ height: 40, mr: 1, ml: 1 }} orientation="vertical" />

--- a/applications/dknet/frontend/src/components/widgets/CustomAutoComplete.tsx
+++ b/applications/dknet/frontend/src/components/widgets/CustomAutoComplete.tsx
@@ -16,7 +16,7 @@ const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
 const checkedIcon = <CheckBoxIcon fontSize="small" />;
 
 
-const CustomAutoComplete = ({ options, placeholder, onChangeFilterValue, defaultValue }) => {
+const CustomAutoComplete = ({ options, placeholder, onChangeFilterValue, isOptionEqualToValue, defaultValue, noOptionsText }) => {
   const [value, setValue] = useState([])
 
   useEffect(() => {
@@ -34,8 +34,8 @@ const CustomAutoComplete = ({ options, placeholder, onChangeFilterValue, default
       filterSelectedOptions
       onChange={(event, value) => onChangeFilterValue(value)}
       ChipProps={{ deleteIcon: <ClearIcon fontSize="small" /> }}
-      isOptionEqualToValue={(option, value) => option.label === value.label}
-      noOptionsText={<Typography variant="caption">No match</Typography>}
+      isOptionEqualToValue={(option, value) => isOptionEqualToValue(option, value)}
+      noOptionsText={<Typography variant="caption">{noOptionsText}</Typography>}
       renderOption={(props, option, { selected }) => (
         <li {...props}>
           <Checkbox


### PR DESCRIPTION
<img width="199" alt="image" src="https://github.com/MetaCell/dknet/assets/67194168/2aacb23d-87c6-4347-ae03-4ad8cec46b81">
<img width="189" alt="image" src="https://github.com/MetaCell/dknet/assets/67194168/697f57f1-9dc9-4d6b-a0e5-66cce6f7123f">
<br/>

Problem: Amend the checkbox multi-select to match the Figma design 
According to the design 
it should look like the image below
<img width="354" alt="image" src="https://github.com/MetaCell/dknet/assets/67194168/c02db813-43b8-44b9-812d-56706c2d61ee">
<br/>

Solution: 
However I found out it to be very cumbersome to be implemented this way 
and found out that there is ready search property in autocomplete mui, which requires much less code and more flexible and it also provides helper text when the search is not matched to the user's entry.

