### PR TITLE
DK2-158 Update on the scoring on the repository card

### DIFF
--- a/applications/dknet/frontend/src/components/RepositoryCard.tsx
+++ b/applications/dknet/frontend/src/components/RepositoryCard.tsx
@@ -60,7 +60,7 @@ const RepositoryCard = (props) => {
                 underline='hover'
                 variant="subtitle1" color="grey.800"
               >
-                {repository.label} - Score: {repository.pctMatch}% ({repository.score} points)
+                {repository.label} - Score: {repository.pctMatch}%
               </CardTitleLink>
             </Tooltip>
           </Box>


### PR DESCRIPTION
Issue: Update on the scoring on the repository card
Solution: Just removed it 
<img width="576" alt="image" src="https://github.com/MetaCell/dknet/assets/67194168/d01ff98f-fbcc-4520-9ed2-d8938435cbf6">
